### PR TITLE
Fix jar resource loading

### DIFF
--- a/persistence/src/main/java/org/granary/database/ConnectionPoolImpl.java
+++ b/persistence/src/main/java/org/granary/database/ConnectionPoolImpl.java
@@ -44,12 +44,15 @@ public class ConnectionPoolImpl implements ConnectionPool {
      */
     private boolean initializeJDBCDriver() {
         if (JDBC_DRIVER.equals(System.getProperty(JDBC_DRIVER_VM_ARG_KEY))) {
+            LOG.info("Successfully loaded JDBC driver class.");
             return true;
         } else {
             try {
                 Class.forName(JDBC_DRIVER);
+                LOG.info("Successfully loaded JDBC driver class.");
                 return true;
             } catch (ClassNotFoundException e) {
+                LOG.error(e.getMessage(), e);
                 return false;
             }
         }
@@ -89,6 +92,7 @@ public class ConnectionPoolImpl implements ConnectionPool {
             }
             return true;
         } catch (PropertyException e) {
+            LOG.error(e.getMessage(), e);
             return false;
         }
     }

--- a/properties/src/main/java/org/granary/properties/Properties.java
+++ b/properties/src/main/java/org/granary/properties/Properties.java
@@ -4,9 +4,11 @@ import org.granary.properties.exception.PropertyException;
 import org.granary.properties.exception.PropertyNotFoundException;
 
 import java.io.BufferedReader;
-import java.io.FileReader;
 import java.io.IOException;
-import java.net.URL;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 public class Properties {
@@ -56,13 +58,12 @@ public class Properties {
             throw new PropertyException("Property key cannot be empty.");
         }
         String key = property.toString();
-        URL prsResource = Properties.class.getClassLoader().getResource(PRS_NAME);
-        if (prsResource == null) {
-            throw new PropertyException(String.format("File '%s' not found.", PRS_NAME));
-        }
-        try (BufferedReader br = new BufferedReader(new FileReader(prsResource.getFile()))) {
+        try (
+                InputStream is = Properties.class.getClassLoader().getResourceAsStream(PRS_NAME);
+                Reader isr = new InputStreamReader(is, StandardCharsets.UTF_8);
+                Reader br = new BufferedReader(isr)
+        ) {
             int next;
-//            char nextChar;
             String keyRead = "";
             boolean readingKey = true;
 
@@ -71,7 +72,6 @@ public class Properties {
                 if (next < 0) {
                     break;
                 }
-//                nextChar = (char) next;
                 switch (next) {
                     case '\n':
                         readingKey = true;
@@ -97,11 +97,7 @@ public class Properties {
         }
     }
 
-    public static void wipeArray(char[] array) {
-        Arrays.fill(array, '0'); // clear heap values
-    }
-
-    private static char[] getSensitiveCharArrayFromLine(BufferedReader br, String key) throws PropertyException {
+    private static char[] getSensitiveCharArrayFromLine(Reader br, String key) throws PropertyException {
         char[] sensitiveArr = new char[VALUE_CHAR_LENGTH_INCREMENT];
         int charactersProcessed = 0;
         try {
@@ -142,5 +138,9 @@ public class Properties {
         }
         wipeArray(sensitiveArr);
         return returnArr;
+    }
+
+    public static void wipeArray(char[] array) {
+        Arrays.fill(array, '0'); // clear heap values
     }
 }


### PR DESCRIPTION
The implementation reading the resource, as opposed to the resource as stream, from the class loader encountered the issue that the path derived from the resulting resource was not a valid file system path, when executing the jar file. The path included the exclamation mark after the jar file, pointing to the .prs file inside the root of the jar.

Getting the resource as a stream instead returns an input stream, which then can be read from successfully.